### PR TITLE
Change friends tiles from img to background-image

### DIFF
--- a/WebApp/css/style.css
+++ b/WebApp/css/style.css
@@ -402,6 +402,10 @@ input[type=submit]:hover {
     text-align: right;
     overflow: hidden;
 }
+.friends .thumb div {
+	background-size: cover;
+	height: 100%;
+}
 .friends .thumb img {
 	position: absolute;
 	top: 0;

--- a/WebApp/friends.html
+++ b/WebApp/friends.html
@@ -9,12 +9,12 @@
 	<div class="widget">
 		<h3>Friends</h3>
 		<div class="group flex friends">
-			<a class="thumb" href><div><img class="overlay" src="img/overlay.png"><img src="img/preska.jpg" alt="Preska"><span class="name">Preska</span></div></a>
-			<a class="thumb" href><div><img class="overlay" src="img/overlay.png"><img src="img/matthew.jpg" alt="Matthew"><span class="name">Matthew</span></div></a>
-			<a class="thumb" href><div><img class="overlay" src="img/overlay.png"><img src="img/zak.jpg" alt="Zak"><span class="name">Zak</span></div></a>
-			<a class="thumb" href><div><img class="overlay" src="img/overlay.png"><img src="img/aneesh.jpg" alt="Aneesh"><span class="name">Aneesh</span></div></a>
-			<a class="thumb" href><div><img class="overlay" src="img/overlay.png"><img src="img/eric.jpg" alt="Eric"><span class="name">Eric</span></div></a>
-			<a class="thumb" href><div><img class="overlay" src="img/overlay.png"><img src="img/preska.jpg" alt="Matthew"><span class="name">Marianne</span></div></a>
+			<a class="thumb" href><div style="background-image: url(img/preska.jpg)"><img class="overlay" src="img/overlay.png"><span class="name">Preska</span></div></a>
+			<a class="thumb" href><div style="background-image: url(img/matthew.jpg)"><img class="overlay" src="img/overlay.png"><span class="name">Matthew</span></div></a>
+			<a class="thumb" href><div style="background-image: url(img/zak.jpg)"><img class="overlay" src="img/overlay.png"><span class="name">Zak</span></div></a>
+			<a class="thumb" href><div style="background-image: url(img/aneesh.jpg)"><img class="overlay" src="img/overlay.png"><span class="name">Aneesh</span></div></a>
+			<a class="thumb" href><div style="background-image: url(img/eric.jpg)"><img class="overlay" src="img/overlay.png"><span class="name">Eric</span></div></a>
+			<a class="thumb" href><div style="background-image: url(img/marianne.jpg)"><img class="overlay" src="img/overlay.png"><span class="name">Marianne</span></div></a>
 		</div>
 	</div>
 </body>


### PR DESCRIPTION
To deal with the size of the profile image in the tiles effectively, I took out the img tag inside the thumbnail div and just set the div to have a background-image instead so that the size of the image will be set to cover instead of having a situation where the given image dimensions do not completely fill the thumbnail div without stretching the dimensions.